### PR TITLE
Global cost tracking

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,7 +73,7 @@ repos:
         additional_dependencies:
           - aiohttp
           - coredis
-          - fhaviary[llm]>=0.8.2 # Match pyproject.toml
+          - fhaviary[llm]>=0.14.0 # Match pyproject.toml
           - litellm>=1.44 # Match pyproject.toml
           - limits
           - numpy

--- a/llmclient/__init__.py
+++ b/llmclient/__init__.py
@@ -3,6 +3,7 @@ from .constants import (
     EXTRA_TOKENS_FROM_USER_ROLE,
     MODEL_COST_MAP,
 )
+from .cost_tracker import track_costs_ctx, track_costs_global
 from .embeddings import (
     EmbeddingModel,
     EmbeddingModes,
@@ -51,5 +52,7 @@ __all__ = [
     "configure_llm_logs",
     "embedding_model_factory",
     "sum_logprobs",
+    "track_costs_ctx",
+    "track_costs_global",
     "validate_json_completion",
 ]

--- a/llmclient/__init__.py
+++ b/llmclient/__init__.py
@@ -3,7 +3,7 @@ from .constants import (
     EXTRA_TOKENS_FROM_USER_ROLE,
     MODEL_COST_MAP,
 )
-from .cost_tracker import track_costs_ctx, track_costs_global
+from .cost_tracker import GLOBAL_COST_TRACKER, cost_tracking_ctx, enable_cost_tracking
 from .embeddings import (
     EmbeddingModel,
     EmbeddingModes,
@@ -35,6 +35,7 @@ from .utils import (
 __all__ = [
     "CHARACTERS_PER_TOKEN_ASSUMPTION",
     "EXTRA_TOKENS_FROM_USER_ROLE",
+    "GLOBAL_COST_TRACKER",
     "MODEL_COST_MAP",
     "Chunk",
     "Embeddable",
@@ -50,9 +51,9 @@ __all__ = [
     "SentenceTransformerEmbeddingModel",
     "SparseEmbeddingModel",
     "configure_llm_logs",
+    "cost_tracking_ctx",
     "embedding_model_factory",
+    "enable_cost_tracking",
     "sum_logprobs",
-    "track_costs_ctx",
-    "track_costs_global",
     "validate_json_completion",
 ]

--- a/llmclient/cost_tracker.py
+++ b/llmclient/cost_tracker.py
@@ -15,7 +15,7 @@ REPORT_EVERY_USD = 1.0
 
 
 def set_reporting_frequency(frequency: float):
-    global REPORT_EVERY_USD  # noqa: PLW0603
+    global REPORT_EVERY_USD  # noqa: PLW0603  # pylint: disable=global-statement
     REPORT_EVERY_USD = frequency
 
 

--- a/llmclient/cost_tracker.py
+++ b/llmclient/cost_tracker.py
@@ -1,0 +1,113 @@
+import contextvars
+import logging
+from collections.abc import Awaitable, Callable
+from contextlib import asynccontextmanager
+from functools import wraps
+from typing import ParamSpec, TypeVar
+
+import litellm
+
+logger = logging.getLogger(__name__)
+
+
+TRACK_COSTS = contextvars.ContextVar[bool]("track_costs", default=False)
+
+
+def track_costs_global(enabled: bool = True):
+    TRACK_COSTS.set(enabled)
+
+
+@asynccontextmanager
+async def track_costs_ctx(enabled: bool = True):
+    prev = TRACK_COSTS.get()
+    TRACK_COSTS.set(enabled)
+    try:
+        yield
+    finally:
+        TRACK_COSTS.set(prev)
+
+
+class CostTracker:
+    def __init__(self):
+        self.lifetime_cost_usd = 0.0
+
+    def record(self, response: litellm.ModelResponse):
+        self.lifetime_cost_usd += litellm.cost_calculator.completion_cost(
+            completion_response=response
+        )
+        logger.info(f"Cumulative llmclient cost: ${self.lifetime_cost_usd:.8f}")
+
+
+GLOBAL_COST_TRACKER = CostTracker()
+
+
+TReturn = TypeVar("TReturn", bound=Awaitable)
+TParams = ParamSpec("TParams")
+
+
+def track_costs(
+    func: Callable[TParams, TReturn],
+) -> Callable[TParams, TReturn]:
+    async def wrapped_func(*args, **kwargs):
+        response = await func(*args, **kwargs)
+        if TRACK_COSTS.get():
+            GLOBAL_COST_TRACKER.record(response)
+        return response
+
+    return wrapped_func
+
+
+class TrackedStreamWrapper:
+    """Class that tracks costs as one iterates through the stream.
+
+    Note that the following is not possible:
+    ```
+    async def wrap(func):
+        resp: CustomStreamWrapper = await func()
+        async for response in resp:
+            yield response
+
+    # This is ok
+    async for resp in await litellm.acompletion(stream=True):
+        print(resp
+
+
+    # This is not, because we cannot await an AsyncGenerator
+    async for resp in await wrap(litellm.acompletion(stream=True)):
+        print(resp)
+    ```
+
+    In order for `track_costs_iter` to not change how users call functions,
+    we introduce this class to wrap the stream.
+    """
+
+    def __init__(self, stream: litellm.CustomStreamWrapper):
+        self.stream = stream
+
+    def __iter__(self):
+        return self
+
+    def __aiter__(self):
+        return self
+
+    def __next__(self):
+        response = next(self.stream)
+        if TRACK_COSTS.get():
+            GLOBAL_COST_TRACKER.record(response)
+        return response
+
+    async def __anext__(self):
+        response = await self.stream.__anext__()
+        if TRACK_COSTS.get():
+            GLOBAL_COST_TRACKER.record(response)
+        return response
+
+
+def track_costs_iter(
+    func: Callable[TParams, TReturn],
+) -> Callable[TParams, Awaitable[TrackedStreamWrapper]]:
+    @wraps(func)
+    async def wrapped_func(*args, **kwargs):
+        return TrackedStreamWrapper(await func(*args, **kwargs))
+
+    return wrapped_func

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
     "coredis",
-    "fhaviary>=0.8.2",  # For core namespace
+    "fhaviary>=0.14.0",  # For multi-image support
     "limits",
     "pydantic~=2.0,>=2.10.1,<2.10.2",
     "tiktoken>=0.4.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import shutil
 from collections.abc import Iterator
+from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
@@ -73,3 +74,10 @@ def fixture_reset_log_levels(caplog) -> Iterator[None]:
         logger = logging.getLogger(name)
         logger.setLevel(logging.NOTSET)
         logger.propagate = True
+
+
+class CILLMModelNames(StrEnum):
+    """Models to use for generic CI testing."""
+
+    ANTHROPIC = "claude-3-haiku-20240307"  # Cheap and not Anthropic's cutting edge
+    OPENAI = "gpt-4o-mini-2024-07-18"  # Cheap and not OpenAI's cutting edge

--- a/tests/test_cost_tracking.py
+++ b/tests/test_cost_tracking.py
@@ -27,7 +27,7 @@ class TestLiteLLMEmbeddingCosts:
     async def test_embed_documents(self):
         stub_texts = ["test1", "test2"]
         with assert_costs_increased():
-            async with track_costs_ctx(enabled=True):
+            async with track_costs_ctx():
                 model = LiteLLMEmbeddingModel(name="text-embedding-3-small", ndim=8)
                 await model.embed_documents(stub_texts)
 
@@ -74,7 +74,7 @@ class TestLiteLLMModel:
     @pytest.mark.asyncio
     async def test_call(self, config: dict[str, Any]) -> None:
         with assert_costs_increased():
-            async with track_costs_ctx(enabled=True):
+            async with track_costs_ctx():
                 llm = LiteLLMModel(name=config["model_name"], config=config)
                 messages = [
                     Message(role="system", content="Respond with single words."),
@@ -89,7 +89,7 @@ class TestLiteLLMModel:
         async def ac(x) -> None:
             pass
 
-        async with track_costs_ctx(enabled=True):
+        async with track_costs_ctx():
             with assert_costs_increased():
                 llm = LiteLLMModel(name="gpt-4o")
                 image = np.zeros((32, 32, 3), dtype=np.uint8)
@@ -140,7 +140,7 @@ class TestLiteLLMModel:
     )
     @pytest.mark.asyncio
     async def test_run_prompt(self, config: dict[str, Any]) -> None:
-        async with track_costs_ctx(enabled=True):
+        async with track_costs_ctx():
             with assert_costs_increased():
                 llm = LiteLLMModel(name="gpt-4o-mini", config=config)
 
@@ -168,7 +168,7 @@ class TestMultipleCompletionLLMModel:
     )
     @pytest.mark.asyncio
     async def test_achat(self, model_name: str) -> None:
-        async with track_costs_ctx(enabled=True):
+        async with track_costs_ctx():
             with assert_costs_increased():
                 model = MultipleCompletionLLMModel(name=model_name)
                 await model.achat(
@@ -189,7 +189,7 @@ class TestMultipleCompletionLLMModel:
     @pytest.mark.asyncio
     @pytest.mark.vcr
     async def test_text_image_message(self, model_name: str) -> None:
-        async with track_costs_ctx(enabled=True):
+        async with track_costs_ctx():
             with assert_costs_increased():
                 model = MultipleCompletionLLMModel(name=model_name, config={"n": 2})
 

--- a/tests/test_cost_tracking.py
+++ b/tests/test_cost_tracking.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 from aviary.core import Message
 
-from llmclient import track_costs_ctx
+from llmclient import cost_tracking_ctx
 from llmclient.cost_tracker import GLOBAL_COST_TRACKER
 from llmclient.embeddings import LiteLLMEmbeddingModel
 from llmclient.llms import LiteLLMModel, MultipleCompletionLLMModel
@@ -27,7 +27,7 @@ class TestLiteLLMEmbeddingCosts:
     async def test_embed_documents(self):
         stub_texts = ["test1", "test2"]
         with assert_costs_increased():
-            async with track_costs_ctx():
+            async with cost_tracking_ctx():
                 model = LiteLLMEmbeddingModel(name="text-embedding-3-small", ndim=8)
                 await model.embed_documents(stub_texts)
 
@@ -74,7 +74,7 @@ class TestLiteLLMModel:
     @pytest.mark.asyncio
     async def test_call(self, config: dict[str, Any]) -> None:
         with assert_costs_increased():
-            async with track_costs_ctx():
+            async with cost_tracking_ctx():
                 llm = LiteLLMModel(name=config["model_name"], config=config)
                 messages = [
                     Message(role="system", content="Respond with single words."),
@@ -89,7 +89,7 @@ class TestLiteLLMModel:
         async def ac(x) -> None:
             pass
 
-        async with track_costs_ctx():
+        async with cost_tracking_ctx():
             with assert_costs_increased():
                 llm = LiteLLMModel(name="gpt-4o")
                 image = np.zeros((32, 32, 3), dtype=np.uint8)
@@ -140,7 +140,7 @@ class TestLiteLLMModel:
     )
     @pytest.mark.asyncio
     async def test_run_prompt(self, config: dict[str, Any]) -> None:
-        async with track_costs_ctx():
+        async with cost_tracking_ctx():
             with assert_costs_increased():
                 llm = LiteLLMModel(name="gpt-4o-mini", config=config)
 
@@ -168,7 +168,7 @@ class TestMultipleCompletionLLMModel:
     )
     @pytest.mark.asyncio
     async def test_achat(self, model_name: str) -> None:
-        async with track_costs_ctx():
+        async with cost_tracking_ctx():
             with assert_costs_increased():
                 model = MultipleCompletionLLMModel(name=model_name)
                 await model.achat(
@@ -189,7 +189,7 @@ class TestMultipleCompletionLLMModel:
     @pytest.mark.asyncio
     @pytest.mark.vcr
     async def test_text_image_message(self, model_name: str) -> None:
-        async with track_costs_ctx():
+        async with cost_tracking_ctx():
             with assert_costs_increased():
                 model = MultipleCompletionLLMModel(name=model_name, config={"n": 2})
 

--- a/tests/test_cost_tracking.py
+++ b/tests/test_cost_tracking.py
@@ -1,0 +1,209 @@
+from contextlib import contextmanager
+from typing import Any
+
+import numpy as np
+import pytest
+from aviary.core import Message
+
+from llmclient import track_costs_ctx
+from llmclient.cost_tracker import GLOBAL_COST_TRACKER
+from llmclient.embeddings import LiteLLMEmbeddingModel
+from llmclient.llms import LiteLLMModel, MultipleCompletionLLMModel
+from llmclient.types import LLMResult
+
+from .conftest import VCR_DEFAULT_MATCH_ON, CILLMModelNames
+
+
+@contextmanager
+def assert_costs_increased():
+    """All tests in this file should increase accumulated costs."""
+    initial_cost = GLOBAL_COST_TRACKER.lifetime_cost_usd
+    yield
+    assert GLOBAL_COST_TRACKER.lifetime_cost_usd > initial_cost
+
+
+class TestLiteLLMEmbeddingCosts:
+    @pytest.mark.asyncio
+    async def test_embed_documents(self):
+        stub_texts = ["test1", "test2"]
+        with assert_costs_increased():
+            async with track_costs_ctx(enabled=True):
+                model = LiteLLMEmbeddingModel(name="text-embedding-3-small", ndim=8)
+                await model.embed_documents(stub_texts)
+
+
+class TestLiteLLMModel:
+    @pytest.mark.vcr(match_on=[*VCR_DEFAULT_MATCH_ON, "body"])
+    @pytest.mark.parametrize(
+        "config",
+        [
+            pytest.param(
+                {
+                    "model_name": "gpt-4o-mini",
+                    "model_list": [
+                        {
+                            "model_name": "gpt-4o-mini",
+                            "litellm_params": {
+                                "model": "gpt-4o-mini",
+                                "temperature": 0,
+                                "max_tokens": 56,
+                            },
+                        }
+                    ],
+                },
+                id="chat-model",
+            ),
+            pytest.param(
+                {
+                    "model_name": "gpt-3.5-turbo-instruct",
+                    "model_list": [
+                        {
+                            "model_name": "gpt-3.5-turbo-instruct",
+                            "litellm_params": {
+                                "model": "gpt-3.5-turbo-instruct",
+                                "temperature": 0,
+                                "max_tokens": 56,
+                            },
+                        }
+                    ],
+                },
+                id="completion-model",
+            ),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_call(self, config: dict[str, Any]) -> None:
+        with assert_costs_increased():
+            async with track_costs_ctx(enabled=True):
+                llm = LiteLLMModel(name=config["model_name"], config=config)
+                messages = [
+                    Message(role="system", content="Respond with single words."),
+                    Message(
+                        role="user", content="What is the meaning of the universe?"
+                    ),
+                ]
+                await llm.call(messages)
+
+    @pytest.mark.asyncio
+    async def test_call_w_figure(self) -> None:
+        async def ac(x) -> None:
+            pass
+
+        async with track_costs_ctx(enabled=True):
+            with assert_costs_increased():
+                llm = LiteLLMModel(name="gpt-4o")
+                image = np.zeros((32, 32, 3), dtype=np.uint8)
+                image[:] = [255, 0, 0]
+                messages = [
+                    Message(
+                        role="system",
+                        content="You are a detective who investigate colors",
+                    ),
+                    Message.create_message(
+                        role="user",
+                        text="What color is this square? Show me your chain of reasoning.",
+                        images=image,
+                    ),
+                ]  # TODO: It's not decoding the image. It's trying to guess the color from the encoded image string.
+                await llm.call(messages)
+
+            with assert_costs_increased():
+                await llm.call(messages, [ac])
+
+    @pytest.mark.vcr(match_on=[*VCR_DEFAULT_MATCH_ON, "body"])
+    @pytest.mark.parametrize(
+        "config",
+        [
+            pytest.param(
+                {
+                    "model_list": [
+                        {
+                            "model_name": "gpt-4o-mini",
+                            "litellm_params": {
+                                "model": "gpt-4o-mini",
+                                "temperature": 0,
+                                "max_tokens": 56,
+                            },
+                        }
+                    ]
+                },
+                id="with-router",
+            ),
+            pytest.param(
+                {
+                    "pass_through_router": True,
+                    "router_kwargs": {"temperature": 0, "max_tokens": 56},
+                },
+                id="without-router",
+            ),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_run_prompt(self, config: dict[str, Any]) -> None:
+        async with track_costs_ctx(enabled=True):
+            with assert_costs_increased():
+                llm = LiteLLMModel(name="gpt-4o-mini", config=config)
+
+                outputs = []
+
+                def accum(x) -> None:
+                    outputs.append(x)
+
+                await llm.run_prompt(
+                    prompt="The {animal} says",
+                    data={"animal": "duck"},
+                    system_prompt=None,
+                    callbacks=[accum],
+                )
+
+
+class TestMultipleCompletionLLMModel:
+    async def call_model(
+        self, model: MultipleCompletionLLMModel, *args, **kwargs
+    ) -> list[LLMResult]:
+        return await model.call(*args, **kwargs)
+
+    @pytest.mark.parametrize(
+        "model_name", ["gpt-3.5-turbo", CILLMModelNames.ANTHROPIC.value]
+    )
+    @pytest.mark.asyncio
+    async def test_achat(self, model_name: str) -> None:
+        async with track_costs_ctx(enabled=True):
+            with assert_costs_increased():
+                model = MultipleCompletionLLMModel(name=model_name)
+                await model.achat(
+                    messages=[
+                        Message(content="What are three things I should do today?"),
+                    ]
+                )
+
+            with assert_costs_increased():
+                async for _ in await model.achat_iter(
+                    messages=[
+                        Message(content="What are three things I should do today?"),
+                    ]
+                ):
+                    pass
+
+    @pytest.mark.parametrize("model_name", [CILLMModelNames.OPENAI.value])
+    @pytest.mark.asyncio
+    @pytest.mark.vcr
+    async def test_text_image_message(self, model_name: str) -> None:
+        async with track_costs_ctx(enabled=True):
+            with assert_costs_increased():
+                model = MultipleCompletionLLMModel(name=model_name, config={"n": 2})
+
+                # An RGB image of a red square
+                image = np.zeros((32, 32, 3), dtype=np.uint8)
+                # (255 red, 0 green, 0 blue) is maximum red in RGB
+                image[:] = [255, 0, 0]
+
+                await self.call_model(
+                    model,
+                    messages=[
+                        Message.create_message(
+                            text="What color is this square? Respond only with the color name.",
+                            images=image,
+                        )
+                    ],
+                )

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -22,7 +22,6 @@ from tests.conftest import VCR_DEFAULT_MATCH_ON
 
 
 class TestLiteLLMModel:
-
     @pytest.mark.vcr(match_on=[*VCR_DEFAULT_MATCH_ON, "body"])
     @pytest.mark.parametrize(
         "config",
@@ -89,7 +88,7 @@ class TestLiteLLMModel:
             Message.create_message(
                 role="user",
                 text="What color is this square? Show me your chain of reasoning.",
-                image=image,
+                images=image,
             ),
         ]  # TODO: It's not decoding the image. It's trying to guess the color from the encoded image string.
         results = await llm.call(messages)
@@ -412,7 +411,7 @@ class TestMultipleCompletionLLMModel:
             messages=[
                 Message.create_message(
                     text="What color is this square? Respond only with the color name.",
-                    image=image,
+                    images=image,
                 )
             ],
         )

--- a/uv.lock
+++ b/uv.lock
@@ -567,7 +567,7 @@ wheels = [
 
 [[package]]
 name = "fh-llm-client"
-version = "0.0.4.dev6+g5a2deb7.d20241210"
+version = "0.0.8.dev2+gf8125c0.d20241231"
 source = { editable = "." }
 dependencies = [
     { name = "coredis" },
@@ -652,7 +652,7 @@ dev = [
 requires-dist = [
     { name = "coredis" },
     { name = "fh-llm-client", extras = ["local"], marker = "extra == 'dev'" },
-    { name = "fhaviary", specifier = ">=0.8.2" },
+    { name = "fhaviary", specifier = ">=0.14.0" },
     { name = "fhaviary", extras = ["xml"], marker = "extra == 'dev'" },
     { name = "ipython", marker = "extra == 'dev'", specifier = ">=8" },
     { name = "limits" },
@@ -688,16 +688,16 @@ dev = [{ name = "fh-llm-client", extras = ["dev"] }]
 
 [[package]]
 name = "fhaviary"
-version = "0.11.0"
+version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docstring-parser" },
     { name = "httpx" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/48/11/5382ad08ed37f7ddb71f74c08e0d052e9bfc710caba370a02e5825f36d7d/fhaviary-0.11.0.tar.gz", hash = "sha256:2d69eac9c8736c910fcf93a058db876d55a34132464d7b2ff485310eb48e1276", size = 242294 }
+sdist = { url = "https://files.pythonhosted.org/packages/00/72/df04af3d1135b2bfb6af59f327c7759358a82c2ca7dad01156d93cddfdb1/fhaviary-0.14.0.tar.gz", hash = "sha256:99751f6484e28d33b585cd47c95142a589e814571509390e213e336cdd8aab7b", size = 311279 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/6d/8382fe777f37c9183f167e5e2de34703340c8196b5adbdf2ab88211910a6/fhaviary-0.11.0-py3-none-any.whl", hash = "sha256:caff1b9d7dd8a0923f4acbd1ce9711a77672af4cbb9b93ecc6c77d465c4a2cad", size = 48921 },
+    { url = "https://files.pythonhosted.org/packages/bb/a1/dfb72d03d72606c1ffc0591bc73b7304dff5c4ca8606fa1e9e8cfbbce1b7/fhaviary-0.14.0-py3-none-any.whl", hash = "sha256:ce1b6950b9719cd321c5afe13edefb429319f54c3f5fb18396a57b22ad465822", size = 52312 },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
I'd like to have a way to track costs across all LLM API usage - including agents and environments. This PR implements that.

I made a few semi-arbitrary choices here - there are other ways of implementing this and I'm open to suggestions.

First: I decided to capture costs at the lowest level (i.e. all calls to `acompletion`, `achat`, etc.). We could alternatively only support functions that return `LLMResult` and use `LLMResult.cost`. But we'd run the risk of not catching everything

Second: `litellm` async streaming calls don't return `AsyncGenerator`s (fixed our type hints), but instead `CustomStreamWrapper`s, which implement `__aiter__` and `__anext__`. I had to create a shim called `TrackedStreamWrapper` to handle this - open to alternative suggestions (see comment in code about why `async for ... yield` doesn't work)