### PR TITLE
Downpinned LiteLLM for `Router.acompletion` typing break

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,7 +75,7 @@ repos:
           - aiohttp
           - coredis
           - fhaviary[llm]>=0.14.0 # Match pyproject.toml
-          - litellm>=1.44 # Match pyproject.toml
+          - litellm>=1.44,<1.57.2 # Match pyproject.toml
           - limits
           - numpy
           - pydantic~=2.0,>=2.10.1,<2.10.2 # Match pyproject.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
     "fh-llm-client[local]",
     "fhaviary[xml]",
     "ipython>=8",  # Pin to keep recent
+    "litellm<1.57.2",  # Pin for Router.acompletion typing break from https://github.com/BerriAI/litellm/pull/7594
     "mypy>=1.8",  # Pin for mutable-override
     "pre-commit>=3.4",  # Pin to keep recent
     "pylint-pydantic",

--- a/uv.lock
+++ b/uv.lock
@@ -537,7 +537,7 @@ wheels = [
 
 [[package]]
 name = "fh-llm-client"
-version = "0.0.9.dev7+g43e2393"
+version = "0.0.10.dev0+g25c76c8.d20250109"
 source = { editable = "." }
 dependencies = [
     { name = "coredis" },
@@ -553,6 +553,7 @@ dependencies = [
 dev = [
     { name = "fhaviary", extra = ["xml"] },
     { name = "ipython" },
+    { name = "litellm" },
     { name = "mypy" },
     { name = "numpy" },
     { name = "pre-commit" },
@@ -579,6 +580,7 @@ codeflash = [
     { name = "codeflash" },
     { name = "fhaviary", extra = ["xml"] },
     { name = "ipython" },
+    { name = "litellm" },
     { name = "mypy" },
     { name = "numpy" },
     { name = "pre-commit" },
@@ -598,6 +600,7 @@ codeflash = [
 dev = [
     { name = "fhaviary", extra = ["xml"] },
     { name = "ipython" },
+    { name = "litellm" },
     { name = "mypy" },
     { name = "numpy" },
     { name = "pre-commit" },
@@ -625,6 +628,7 @@ requires-dist = [
     { name = "limits" },
     { name = "litellm", marker = "python_full_version < '3.13'" },
     { name = "litellm", marker = "python_full_version >= '3.13'", specifier = ">=1.49.1" },
+    { name = "litellm", marker = "extra == 'dev'", specifier = "<1.57.2" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8" },
     { name = "numpy", marker = "extra == 'local'" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.4" },


### PR DESCRIPTION
As seen in [this CI run](https://github.com/Future-House/llm-client/actions/runs/12681627391/job/35345684763), https://github.com/BerriAI/litellm/pull/7594 broke `Router.acompletion`'s typing:

```none
llmclient/llms.py: note: In member "achat" of class "LiteLLMModel":
llmclient/llms.py:621:74: error: Argument 2 has incompatible type
"list[dict[Any, Any]]"; expected
"list[ChatCompletionUserMessage | ChatCompletionAssistantMessage | ChatCompletionToolMessage | ChatCompletionSystemMessage | ChatCompletionFunctionMessage]"
 [arg-type]
    ...ponse = await track_costs(self.router.acompletion)(self.name, prompts)
                                                                     ^~~~~~~
```

This doesn't actually impact runtime usage, but it does impact type checkers. So as a short-term workaround, I just downpin LiteLLM here.