### PR TITLE
Loosening `LLMModel.run_prompt` to allow for `Iterable[Callback]`

### DIFF
--- a/llmclient/llms.py
+++ b/llmclient/llms.py
@@ -261,7 +261,7 @@ class LLMModel(ABC, BaseModel):
         self,
         prompt: str,
         data: dict,
-        callbacks: list[Callable] | None = None,
+        callbacks: Iterable[Callable] | None = None,
         name: str | None = None,
         system_prompt: str | None = default_system_prompt,
     ) -> LLMResult:


### PR DESCRIPTION
https://github.com/Future-House/llm-client/pull/35 missed `run_prompt`