### PR TITLE
Fixing LiteLLM `Router.acompletion` typing issue

### DIFF
--- a/llmclient/llms.py
+++ b/llmclient/llms.py
@@ -553,7 +553,11 @@ class LiteLLMModel(LLMModel):
 
     @rate_limited
     async def acompletion(self, messages: list[Message], **kwargs) -> list[LLMResult]:
-        prompts = [m.model_dump(by_alias=True) for m in messages if m.content]
+        # cast is necessary for LiteLLM typing bug: https://github.com/BerriAI/litellm/issues/7641
+        prompts = cast(
+            list[litellm.types.llms.openai.AllMessageValues],
+            [m.model_dump(by_alias=True) for m in messages if m.content],
+        )
         completions = await track_costs(self.router.acompletion)(
             self.name, prompts, **kwargs
         )
@@ -602,7 +606,11 @@ class LiteLLMModel(LLMModel):
     async def acompletion_iter(
         self, messages: list[Message], **kwargs
     ) -> AsyncIterable[LLMResult]:
-        prompts = [m.model_dump(by_alias=True) for m in messages if m.content]
+        # cast is necessary for LiteLLM typing bug: https://github.com/BerriAI/litellm/issues/7641
+        prompts = cast(
+            list[litellm.types.llms.openai.AllMessageValues],
+            [m.model_dump(by_alias=True) for m in messages if m.content],
+        )
         stream_completions = await track_costs_iter(self.router.acompletion)(
             self.name,
             prompts,


### PR DESCRIPTION
Working around https://github.com/BerriAI/litellm/issues/7641

Alternately, could do something like this and place it into a `list` comprehension, but I don't like it

```python
def to_openai_msg(message: Message) -> litellm.types.llms.openai.AllMessageValues:
    if message.role == "user":
        return litellm.types.llms.openai.ChatCompletionUserMessage(
            content=message.content, role="user"
        )
    if message.role == "system":
        return litellm.types.llms.openai.ChatCompletionSystemMessage(
            content=message.content, role="system"
        )
    ...
```