### PR TITLE
Saved result name in LLMResult

### DIFF
--- a/llmclient/llms.py
+++ b/llmclient/llms.py
@@ -344,7 +344,7 @@ class LLMModel(ABC, BaseModel):
             result.seconds_to_last_token = (
                 asyncio.get_running_loop().time() - start_clock
             )
-
+            result.name = name
             if self.llm_result_callback:
                 possibly_awaitable_result = self.llm_result_callback(result)
                 if isawaitable(possibly_awaitable_result):

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -104,7 +104,8 @@ class TestLiteLLMModel:
             Message(role="system", content="Respond with single words."),
             Message(role="user", content="What is the meaning of the universe?"),
         ]
-        results = await llm.call(messages)
+        result_name = f"test-{llm.name}"
+        results = await llm.call(messages, name=result_name)
         assert isinstance(results, list)
 
         result = results[0]
@@ -116,7 +117,7 @@ class TestLiteLLMModel:
         assert result.prompt[1].content
         assert result.text
         assert result.logprob is None or result.logprob <= 0
-
+        assert result.name == result_name
         result = await llm.call_single(messages)
         assert isinstance(result, LLMResult)
 


### PR DESCRIPTION
I probably dropped this feature without noticing during the refactoring, and our tests did not cover it. 

I fixed it and added this assertion to `test_call`